### PR TITLE
Bugfix: included scroll bar in width calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Define breakpoints for your responsive design, and Breakpoints.js will fire cust
 [View Demo](http://xoxco.com/projects/code/breakpoints/)
 
 Created by [XOXCO](http://xoxco.com)
+With contributions from [352 Media Group](http://www.352media.com/)
 
 ## Instructions
 

--- a/breakpoints.js
+++ b/breakpoints.js
@@ -1,11 +1,13 @@
 /*
 	Breakpoints.js
-	version 1.0
+	version 1.1
 	
 	Creates handy events for your responsive design breakpoints
 	
-	Copyright 2011 XOXCO, Inc
+	Copyright 2011-2012 XOXCO, Inc
 	http://xoxco.com/
+	With contributions from 352 Media Group
+	http://www.352media.com/
 
 	Documentation for this plugin lives here:
 	http://xoxco.com/projects/code/breakpoints
@@ -27,6 +29,32 @@
 		lastSize = 0;
 	};
 	
+		var scrollbarWidth = 0;
+
+		$.getScrollbarWidth = function() {
+		/* Gets the width of the OS scrollbar		
+		https://github.com/brandonaaron/jquery-getscrollbarwidth/blob/master/jquery.getscrollbarwidth.js */
+		
+			if ( !scrollbarWidth ) {
+				if ( $.browser.msie ) {
+					var $textarea1 = $('<textarea cols="10" rows="2"></textarea>')
+					.css({ position: 'absolute', top: -1000, left: -1000 }).appendTo('body'),
+					$textarea2 = $('<textarea cols="10" rows="2" style="overflow: hidden;"></textarea>')
+					.css({ position: 'absolute', top: -1000, left: -1000 }).appendTo('body');
+					scrollbarWidth = $textarea1.width() - $textarea2.width();
+					$textarea1.add($textarea2).remove();
+				} else {
+					var $div = $('<div />')
+					.css({ width: 100, height: 100, overflow: 'auto', position: 'absolute', top: -1000, left: -1000 })
+					.prependTo('body').append('<div />').find('div')
+					.css({ width: '100%', height: 200 });
+					scrollbarWidth = 100 - $div.width();
+					$div.parent().remove();
+				}
+			}
+		return scrollbarWidth;
+		};
+	
 	$.fn.setBreakpoints = function(settings) {
 		var options = jQuery.extend({
 							distinct: true,
@@ -36,7 +64,8 @@
 
 		interval = setInterval(function() {
 	
-			var w = $(window).width();
+			var w = $(window).width() + $.getScrollbarWidth();
+			// For continuous (i.e., most non-print) media, the width specified in a CSS media query includes the scrollbar (if one exists). jQuery won't include the scrollbar in its width calculation, so we need to add the width of the scrollbar ourselves.
 			var done = false;
 			
 			for (var bp in options.breakpoints.sort(function(a,b) { return (b-a) })) {


### PR DESCRIPTION
Hey Ben,

I've fixed a bug that I mentioned to you on Twitter a few weeks ago. jQuery doesn't include the scrollbar when calculating window width, but media queries [do include the scrollbar width](http://www.w3.org/TR/css3-mediaqueries/#width). This causes problems on OSes that display scrollbars even when the user isn't scrolling. This happens on Windows and on Mac OS 10.6 and earlier.

As a result, on these platforms the breakpoint that's detected in JS is different from the breakpoint that is actually active. [(Screenshot)](http://cl.ly/CjR4)

To fix the problem, I'm using [jquery.getscrollbarwidth](https://github.com/brandonaaron/jquery-getscrollbarwidth/blob/master/jquery.getscrollbarwidth.js) to calculate the width of the scrollbar, then adding that value to the width that jQuery provides.

Please let me know if you have any questions, and thanks for building this awesome script!

Best,
Ryan
