### PR TITLE
More accurate calculations on non-WebKit browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Created by [XOXCO](http://xoxco.com) with contributions from [352 Media Group](h
 
 ## Instructions
 
-	'''javascript
 	$(window).setBreakpoints({
 	// use only largest available vs use all available
 		distinct: true, 
@@ -48,4 +47,4 @@ Created by [XOXCO](http://xoxco.com) with contributions from [352 Media Group](h
 	$(window).bind('exitBreakpoint1024',function() {
 		...
 	});
-	'''
+

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Define breakpoints for your responsive design, and Breakpoints.js will fire cust
 [View Demo](http://xoxco.com/projects/code/breakpoints/)
 
 Created by [XOXCO](http://xoxco.com)
+With contributions from [352 Media Group](http://www.352media.com/)
 
 ## Instructions
 

--- a/README.md
+++ b/README.md
@@ -2,14 +2,15 @@
 
 Define breakpoints for your responsive design, and Breakpoints.js will fire custom events when the browser enters and/or exits that breakpoint.
 
-[Get it from Github](https://github.com/xoxco/breakpoints)
+[Get it from Github](https://github.com/352Media/breakpoints)
 
 [View Demo](http://xoxco.com/projects/code/breakpoints/)
 
-Created by [XOXCO](http://xoxco.com) with contributions from [352 Media Group](http://www.352media.com/)
+Created by [XOXCO](http://xoxco.com) with contributions from [352 Media Group](http://www.352media.com/). This 352 Media Group branch includes more accurate calculations for non-WebKit browsers but is otherwise identical to XOXCO's version of the plugin. See [this pull request](https://github.com/xoxco/breakpoints/pull/6) for details.
 
 ## Instructions
 
+	'''javascript
 	$(window).setBreakpoints({
 	// use only largest available vs use all available
 		distinct: true, 
@@ -47,4 +48,4 @@ Created by [XOXCO](http://xoxco.com) with contributions from [352 Media Group](h
 	$(window).bind('exitBreakpoint1024',function() {
 		...
 	});
-
+	'''

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ Define breakpoints for your responsive design, and Breakpoints.js will fire cust
 
 [View Demo](http://xoxco.com/projects/code/breakpoints/)
 
-Created by [XOXCO](http://xoxco.com)
-With contributions from [352 Media Group](http://www.352media.com/)
+Created by [XOXCO](http://xoxco.com) with contributions from [352 Media Group](http://www.352media.com/)
 
 ## Instructions
 

--- a/breakpoints.js
+++ b/breakpoints.js
@@ -64,8 +64,14 @@
 
 		interval = setInterval(function() {
 	
-			var w = $(window).width() + $.getScrollbarWidth();
-			// For continuous (i.e., most non-print) media, the width specified in a CSS media query includes the scrollbar (if one exists). jQuery won't include the scrollbar in its width calculation, so we need to add the width of the scrollbar ourselves.
+			var w;
+			if ($.browser.webkit) {
+				w = $(window).width();
+			} else {
+				w = $(window).width() + $.getScrollbarWidth();
+			}
+
+			// For continuous (i.e., most non-print) media, the width specified in a media query includes the scrollbar (if one exists). In WebKit, .width() includes the scrollbar. In other browsers, it does not, so we need to add the width of the scrollbar ourselves.
 			var done = false;
 			
 			for (var bp in options.breakpoints.sort(function(a,b) { return (b-a) })) {

--- a/breakpoints.js
+++ b/breakpoints.js
@@ -1,11 +1,13 @@
 /*
 	Breakpoints.js
-	version 1.0
+	version 1.1
 	
 	Creates handy events for your responsive design breakpoints
 	
-	Copyright 2011 XOXCO, Inc
+	Copyright 2011-2012 XOXCO, Inc
 	http://xoxco.com/
+	With contributions from 352 Media Group
+	http://www.352media.com/
 
 	Documentation for this plugin lives here:
 	http://xoxco.com/projects/code/breakpoints
@@ -27,6 +29,32 @@
 		lastSize = 0;
 	};
 	
+		var scrollbarWidth = 0;
+
+		$.getScrollbarWidth = function() {
+		/* Gets the width of the OS scrollbar		
+		https://github.com/brandonaaron/jquery-getscrollbarwidth/blob/master/jquery.getscrollbarwidth.js */
+		
+			if ( !scrollbarWidth ) {
+				if ( $.browser.msie ) {
+					var $textarea1 = $('<textarea cols="10" rows="2"></textarea>')
+					.css({ position: 'absolute', top: -1000, left: -1000 }).appendTo('body'),
+					$textarea2 = $('<textarea cols="10" rows="2" style="overflow: hidden;"></textarea>')
+					.css({ position: 'absolute', top: -1000, left: -1000 }).appendTo('body');
+					scrollbarWidth = $textarea1.width() - $textarea2.width();
+					$textarea1.add($textarea2).remove();
+				} else {
+					var $div = $('<div />')
+					.css({ width: 100, height: 100, overflow: 'auto', position: 'absolute', top: -1000, left: -1000 })
+					.prependTo('body').append('<div />').find('div')
+					.css({ width: '100%', height: 200 });
+					scrollbarWidth = 100 - $div.width();
+					$div.parent().remove();
+				}
+			}
+		return scrollbarWidth;
+		};
+	
 	$.fn.setBreakpoints = function(settings) {
 		var options = jQuery.extend({
 							distinct: true,
@@ -36,7 +64,8 @@
 
 		interval = setInterval(function() {
 	
-			var w = $(window).width();
+			var w = $(window).width() + $.getScrollbarWidth();
+			// For continuous (i.e., most non-print) media, the width specified in a CSS media query includes the scrollbar (if one exists). jQuery won't include the scrollbar in its width calculation, so we need to add the width of the scrollbar ourselves.
 			var done = false;
 			
 			for (var bp in options.breakpoints.sort(function(a,b) { return (b-a) })) {


### PR DESCRIPTION
Hello,

I've fixed a bug that I mentioned to you on Twitter a while back. The fix now works in all major browsers.

On most browsers, the value returned by $.width() doesn't include the scrollbar width. The one exception is WebKit. Media queries [do include the scrollbar width](http://www.w3.org/TR/css3-mediaqueries/#width).

As a result, when you run the current version of breakpoints.js on a non-WebKit browser, the breakpoint that's detected in JS is sometimes different from the breakpoint that is actually active. [(Screenshot)](http://cl.ly/CjR4)

To fix the problem, I'm using [jquery.getscrollbarwidth](https://github.com/brandonaaron/jquery-getscrollbarwidth/blob/master/jquery.getscrollbarwidth.js) to calculate the width of the scrollbar, then adding that value to the width that jQuery provides. On WebKit, I'm just accepting the width value without adding the scrollbar width.

Please let me know if you have any questions, and thanks for building this awesome script!

Best,
Ryan
